### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,6 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-
   end
 
   def create

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,0 +1,6 @@
+class History < ApplicationRecord
+
+ belongs_to :item
+ belongs_to :user
+ has_one :destination
+end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,6 +1,6 @@
 class History < ApplicationRecord
 
- belongs_to :item
- belongs_to :user
- has_one :destination
+#  belongs_to :item
+#  belongs_to :user
+#  has_one :destination
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,6 +1,5 @@
 class History < ApplicationRecord
-
-#  belongs_to :item
-#  belongs_to :user
-#  has_one :destination
+  #  belongs_to :item
+  #  belongs_to :user
+  #  has_one :destination
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,9 @@ class Item < ApplicationRecord
   validates :ship_date_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :image, presence:true
   has_one_attached :image
+
   belongs_to :user
+  has_one :history
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   belongs_to :user
-  has_one :history
+  # has_one :history
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   validates :condition_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :from_id,      numericality: { other_than: 1, message: "can't be blank" }
   validates :ship_date_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :image, presence:true
+  validates :image, presence: true
   has_one_attached :image
 
   belongs_to :user

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -163,6 +163,7 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,6 +179,7 @@
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -120,7 +120,7 @@
   </div>
   <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
+
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
@@ -128,7 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 商品一覧 %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -136,11 +136,11 @@
           <%= image_tag(item.image, class: "item-img") %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <% if item.history.present? %> 
+          <%# <% if item.history.present? %>  %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <% end %>
+          <%# <% end %> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
@@ -159,10 +159,8 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <%# 商品がない場合のダミー商品 %>
       <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -182,8 +180,7 @@
         <% end %>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# //商品がない場合のダミー商品  %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,24 +129,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag(item.image, class: "item-img") %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.history.present? %> 
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.fee %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,6 +158,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -149,7 +149,7 @@
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.fee %></span>
+            <span><%= item.price %>円<br><%= item.fee.name%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/db/migrate/20220628095202_create_histories.rb
+++ b/db/migrate/20220628095202_create_histories.rb
@@ -1,8 +1,8 @@
 class CreateHistories < ActiveRecord::Migration[6.0]
-  def change
-    create_table :histories do |t|
+  # def change
+  #   create_table :histories do |t|
       
-      t.timestamps
-    end
-  end
+  #     t.timestamps
+  #   end
+  # end
 end

--- a/db/migrate/20220628095202_create_histories.rb
+++ b/db/migrate/20220628095202_create_histories.rb
@@ -1,0 +1,8 @@
+class CreateHistories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :histories do |t|
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220628100830_add_details_to_histories.rb
+++ b/db/migrate/20220628100830_add_details_to_histories.rb
@@ -1,6 +1,6 @@
 class AddDetailsToHistories < ActiveRecord::Migration[6.0]
   def change
-    add_reference :histories, :user, foreign_key: true
-    add_reference :histories, :item, foreign_key: true
+    # add_reference :histories, :user, foreign_key: true
+    # add_reference :histories, :item, foreign_key: true
   end
 end

--- a/db/migrate/20220628100830_add_details_to_histories.rb
+++ b/db/migrate/20220628100830_add_details_to_histories.rb
@@ -1,0 +1,6 @@
+class AddDetailsToHistories < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :histories, :user, foreign_key: true
+    add_reference :histories, :item, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_28_074830) do
+ActiveRecord::Schema.define(version: 2022_06_28_100830) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2022_06_28_074830) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.bigint "item_id"
+    t.index ["item_id"], name: "index_histories_on_item_id"
+    t.index ["user_id"], name: "index_histories_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +76,7 @@ ActiveRecord::Schema.define(version: 2022_06_28_074830) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "histories", "items"
+  add_foreign_key "histories", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :history do
+    
+  end
+end

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :history do
-    
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     condition_id          { Faker::Number.between(from: 2, to: 7) }
     from_id               { Faker::Number.between(from: 2, to: 48) }
     ship_date_id          { Faker::Number.between(from: 2, to: 4) }
-    association :user 
+    association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe History, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -72,20 +72,20 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it 'priceが10,000,000以上だと出品できない' do
-      @item.price = 10000000
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
+        @item.price = 10_000_000
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
       it 'imageが空だと出品できない' do
         @item.image = nil
         @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("Image can't be blank")
       end
-      it 'userが紐づいていないと出品できない'do
-      @item.user = nil
-      @item.valid?
-      expect(@item.errors.full_messages).to include('User must exist')
-    end
+      it 'userが紐づいていないと出品できない' do
+        @item.user = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include('User must exist')
+      end
     end
   end
 end


### PR DESCRIPTION
What 
トップページの商品一覧表示画面にデータベースに保存している商品を表示するように設定
データベースに商品がない場合はダミーを表示するように設定

Why
商品一覧表示機能の実装のため


商品のデータがない場合は、ダミー商品が表示されている動画
[https://gyazo.com/576b24a9005bd0aa4156c329d4a2833d](url)

商品のデータがある場合は、商品が一覧で表示されている動画
[https://gyazo.com/5a23c8eb14055a46461a517cce5f36c5](url)